### PR TITLE
testinfra: Allow ASA EC2 Instance to run in any subscribed account and region

### DIFF
--- a/testinfra/asav.tf
+++ b/testinfra/asav.tf
@@ -45,8 +45,34 @@ resource "aws_network_interface" "if" {
   source_dest_check = false
 }
 
+#
+# Note, you have to manually subscribe to this first in 
+# the console.
+#
+# https://aws.amazon.com/marketplace/pp/B00WH2LGM0
+#
+data "aws_ami" "asav" {
+  most_recent = true
+  owners      = ["aws-marketplace"]
+
+  filter {
+    name   = "name"
+    values = ["asav*"]
+  }
+
+  filter {
+    name   = "product-code"
+    values = ["80uds1joqwlz35hw1lx5h1bcc"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
 resource "aws_instance" "asav" {
-  ami           = "${var.asav_ami_id}"
+  ami           = "${data.aws_ami.asav.id}"
   instance_type = "c4.large"
   key_name      = "${aws_key_pair.ssh.key_name}"
 

--- a/testinfra/main.tf
+++ b/testinfra/main.tf
@@ -1,3 +1,7 @@
-provider "aws" {
-  region = "${var.aws_region}"
+provider "aws" {}
+
+data "aws_availability_zones" "available" {
+  # c4.large instance type not available in these AZ
+  blacklisted_zone_ids = ["usw2-az4"]
+  state                = "available"
 }

--- a/testinfra/network.tf
+++ b/testinfra/network.tf
@@ -11,8 +11,9 @@ resource "aws_internet_gateway" "gw" {
 }
 
 resource "aws_subnet" "main" {
-  vpc_id     = "${aws_vpc.main.id}"
-  cidr_block = "10.0.0.0/24"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  cidr_block        = "10.0.0.0/24"
+  vpc_id            = "${aws_vpc.main.id}"
 
   tags = {
     Name = "terraform-provider-ciscoasa acc test"

--- a/testinfra/variables.tf
+++ b/testinfra/variables.tf
@@ -1,21 +1,7 @@
-variable "aws_region" {
-  default = "eu-central-1"
-}
-
 variable "admin_username" {
   default = "admin"
 }
 
 variable "admin_password" {
   default = "acctest"
-}
-
-#
-# Note, you have to manually subscribe to this first in 
-# the console I believe.
-#
-# https://aws.amazon.com/marketplace/pp/B00WH2LGM0
-#
-variable "asav_ami_id" {
-  default = "ami-12f0d2f9"
 }


### PR DESCRIPTION
Previously this was pinned to `eu-central-1` region. Verified locally with `us-west-2` region with SSH.